### PR TITLE
Feature: Log Injection

### DIFF
--- a/npm/src/fail-whale.ts
+++ b/npm/src/fail-whale.ts
@@ -1,10 +1,10 @@
-export function failWhale(message?: string) {
-    console.error("▄████████████▄▐█▄▄▄▄█▌")
-    console.error("█████▌▄▌▄▐▐▌██▌▀▀██▀▀")
-    console.error("███▄█▌▄▌▄▐▐▌▀██▄▄█▌")
-    console.error("▄▄▄▄█████████████")
+export function failWhale(message?: string, logger: any = console) {
+    logger.error("▄████████████▄▐█▄▄▄▄█▌")
+    logger.error("█████▌▄▌▄▐▐▌██▌▀▀██▀▀")
+    logger.error("███▄█▌▄▌▄▐▐▌▀██▄▄█▌")
+    logger.error("▄▄▄▄█████████████")
 
     if (message) {
-        console.error(message)
+        logger.error(message)
     }
 }

--- a/npm/src/tests/fail-whale.test.ts
+++ b/npm/src/tests/fail-whale.test.ts
@@ -4,8 +4,21 @@ describe('print test', () => {
     it('can print without message', () => {
         console.error = jest.fn();
         console.log = jest.fn();
-        failWhale('hello');
-        expect(console.error).toHaveBeenCalled();
+        failWhale();
+        expect(console.error).toHaveBeenCalledTimes(4);
         expect(console.log).not.toHaveBeenCalled();
+    });
+
+    it('can take custom logger', () => {
+        const logWarn = {
+            error: (msg: any) => console.warn(msg)
+        }
+        logWarn.error = jest.fn();
+        console.error = jest.fn();
+        console.log = jest.fn();
+        failWhale('hello', logWarn);
+        expect(console.error).not.toHaveBeenCalled();
+        expect(console.log).not.toHaveBeenCalled();
+        expect(logWarn.error).toHaveBeenCalledTimes(5);
     });
 });


### PR DESCRIPTION
### Summary

This PR aims to extend the already laudable achievement of the Fail Whale by supporting its integration with custom loggers. Any logger implementing an `error` method can now be injected into the whale call. 

### Future Development

- The parameters could be turned into an object, which would allow the injection of the logger without needing any empty string as the message (if no message is the desired behavior), but this would make the whale syntax more verbose, so it has been omitted here.
- The initial motivation for this PR was to limit the number of `error` calls by composing a log string and logging it out with a single error call, but when disabling pretty print, the whale becomes flattened. Obviously, this is a highly undesirable result, though perhaps it is an issue that could be managed with some configuration.
