### PR TITLE
Tighter Logger Typing

### DIFF
--- a/npm/src/fail-whale.ts
+++ b/npm/src/fail-whale.ts
@@ -1,4 +1,8 @@
-export function failWhale(message?: string, logger: any = console) {
+interface ValidLogger {
+    error: (msg: string) => any
+}
+
+export function failWhale(message?: string, logger: ValidLogger = console) {
     logger.error("▄████████████▄▐█▄▄▄▄█▌")
     logger.error("█████▌▄▌▄▐▐▌██▌▀▀██▀▀")
     logger.error("███▄█▌▄▌▄▐▐▌▀██▄▄█▌")


### PR DESCRIPTION
When using fail whale in TS, this PR should throw an error if the injected logger does not have the appropriate method defined. 